### PR TITLE
Add `scale` and `kernel` as class attributes to GranulationKernel

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -6,6 +6,8 @@ on:
       - main
       - develop
   workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build-linux:

--- a/vspec_vsm/granules.py
+++ b/vspec_vsm/granules.py
@@ -32,7 +32,8 @@ class GranulationKernel(kernels.Kernel):
     ----------
     .. [1] Gordon, T. A., Agol, E., & Foreman-Mackey, D. 2020, AJ, 160, 240
     """
-
+    scale: jnp.ndarray
+    freq: jnp.ndarray
     def __init__(self, scale, period):
         self.scale = jnp.atleast_1d(scale)
         self.freq = 1/jnp.atleast_1d(period)


### PR DESCRIPTION
Fixes errors raised by the `equinox` package